### PR TITLE
Add inflection helpers to Go analyzer

### DIFF
--- a/pkg/analyzer/inflect.go
+++ b/pkg/analyzer/inflect.go
@@ -1,0 +1,87 @@
+package analyzer
+
+import (
+	"morphy/pkg/analysis"
+	"morphy/pkg/tagset"
+)
+
+// Inflect inflects a parsed word to match required grammemes.
+func (m *MorphAnalyzer) Inflect(p analysis.Parse, required []string) (analysis.Parse, bool) {
+	lexeme := m.GetLexeme(p)
+	matches := make([]analysis.Parse, 0, len(lexeme))
+	for _, f := range lexeme {
+		if containsAll(f.Tag, required) {
+			matches = append(matches, f)
+		}
+	}
+	if len(matches) == 0 {
+		required = tagset.FixRareCases(required)
+		for _, f := range lexeme {
+			if containsAll(f.Tag, required) {
+				matches = append(matches, f)
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return analysis.Parse{}, false
+	}
+	grams, err := p.Tag.UpdatedGrammemes(required)
+	if err != nil {
+		return analysis.Parse{}, false
+	}
+	best := matches[0]
+	bestScore := similarity(grams, best.Tag.Grammemes())
+	for _, cand := range matches[1:] {
+		s := similarity(grams, cand.Tag.Grammemes())
+		if s > bestScore {
+			best = cand
+			bestScore = s
+		}
+	}
+	return best, true
+}
+
+// MakeAgreeWithNumber inflects the word so it agrees with provided number.
+func (m *MorphAnalyzer) MakeAgreeWithNumber(p analysis.Parse, num int) (analysis.Parse, bool) {
+	grams := p.Tag.NumeralAgreementGrammemes(num)
+	return m.Inflect(p, grams)
+}
+
+func containsAll(tag *tagset.Tag, grams []string) bool {
+	for _, g := range grams {
+		ok, _ := tag.Contains(g)
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func similarity(a []string, b []string) float64 {
+	setA := make(map[string]struct{}, len(a))
+	setB := make(map[string]struct{}, len(b))
+	for _, g := range a {
+		setA[g] = struct{}{}
+	}
+	for _, g := range b {
+		setB[g] = struct{}{}
+	}
+	inter := 0
+	for g := range setA {
+		if _, ok := setB[g]; ok {
+			inter++
+		}
+	}
+	symdiff := 0
+	for g := range setA {
+		if _, ok := setB[g]; !ok {
+			symdiff++
+		}
+	}
+	for g := range setB {
+		if _, ok := setA[g]; !ok {
+			symdiff++
+		}
+	}
+	return float64(inter) - 0.1*float64(symdiff)
+}

--- a/pkg/analyzer/inflect_test.go
+++ b/pkg/analyzer/inflect_test.go
@@ -1,0 +1,51 @@
+package analyzer
+
+import (
+	"testing"
+
+	"morphy/pkg/analysis"
+	"morphy/pkg/tagset"
+	"morphy/pkg/units"
+)
+
+type dummyUnit struct {
+	units.BaseAnalyzerUnit
+	lexeme []analysis.Parse
+}
+
+func (u *dummyUnit) Parse(word, wordLower string, seen map[string]struct{}) []analysis.Parse {
+	return nil
+}
+func (u *dummyUnit) Normalized(p analysis.Parse) analysis.Parse  { return p }
+func (u *dummyUnit) GetLexeme(p analysis.Parse) []analysis.Parse { return u.lexeme }
+func (u *dummyUnit) Clone() units.AnalyzerUnit                   { return u }
+
+type dummyMethod struct{ u *dummyUnit }
+
+func (m dummyMethod) Unit() units.AnalyzerUnit { return m.u }
+
+func TestInflectAndAgree(t *testing.T) {
+	tagSingNomn, _ := tagset.New("NOUN,anim,femn sing,nomn")
+	tagSingGent, _ := tagset.New("NOUN,anim,femn sing,gent")
+	tagPlurNomn, _ := tagset.New("NOUN,anim,femn plur,nomn")
+	tagPlurGent, _ := tagset.New("NOUN,anim,femn plur,gent")
+	du := &dummyUnit{}
+	method := dummyMethod{u: du}
+	lexeme := []analysis.Parse{
+		analysis.NewParse("мама", tagSingNomn, "мама", 1.0, []interface{}{method}),
+		analysis.NewParse("мамы", tagSingGent, "мама", 1.0, []interface{}{method}),
+		analysis.NewParse("мамы", tagPlurNomn, "мама", 1.0, []interface{}{method}),
+		analysis.NewParse("мам", tagPlurGent, "мама", 1.0, []interface{}{method}),
+	}
+	du.lexeme = lexeme
+	base := lexeme[0]
+	m := &MorphAnalyzer{}
+	res, ok := m.Inflect(base, []string{"plur", "gent"})
+	if !ok || res.Word != "мам" {
+		t.Fatalf("expected мам, got %v ok=%v", res.Word, ok)
+	}
+	res2, ok := m.MakeAgreeWithNumber(base, 3)
+	if !ok || res2.Word != "мамы" {
+		t.Fatalf("expected мамы, got %v ok=%v", res2.Word, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- support grammeme updates and numeral agreement in tagset
- add inflect and MakeAgreeWithNumber helpers to Go analyzer
- cover inflection logic with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1913bbb0083239118c6010f3af09e